### PR TITLE
Retrieve data from your St. Paul Crime API

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
             "email": "kule2623@stthomas.edu"
         },
         {
-            "name": "Chris Roon",
+            "name": "Chris Rooney",
             "email": "roon4169@stthomas.edu"
         },
         {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -90,12 +90,12 @@ export default {
             });
         },
         clearMarkers() {
-            $(".leaflet-marker-icon").remove(); 
+            $('.leaflet-marker-icon.leaflet-zoom-animated.leaflet-interactive:not(".huechange")').remove();
             $(".leaflet-popup").remove();
-            $(".leaflet-pane.leaflet-shadow-pane").remove();
+            // $(".leaflet-pane.leaflet-shadow-pane").remove();
         },
-        isInBoundingBox(lat, lon, x1, x2, y1, y2) {
-            return lat >= x1 && lat <= x2 && lon >= y1 && lon <= y2;
+        isInBoundingBox(lat, lon) {
+            return lat >= this.leaflet.bounds.se.lat && lat <= this.leaflet.bounds.nw.lat && lon >= this.leaflet.bounds.nw.lng && lon <= this.leaflet.bounds.se.lng;
         },
         onInput(e) {
             this.currentAddress = e.target.value;
@@ -104,7 +104,7 @@ export default {
             this.inputError = false;
             this.getJSON(`https://nominatim.openstreetmap.org/search?q=${encodeURI(this.currentAddress)}&format=json`).then((result) => {
                 const {lat, lon} = result[0];
-                if(this.isInBoundingBox(lat, lon, this.leaflet.bounds.se.lat, this.leaflet.bounds.nw.lat, this.leaflet.bounds.nw.lng, this.leaflet.bounds.se.lng)) {
+                if(this.isInBoundingBox(lat, lon)) {
                     this.clearMarkers();
                     this.currentMarker = L.marker([lat, lon]).addTo(this.leaflet.map);
                     this.leaflet.map.panTo([lat, lon]);
@@ -151,6 +151,14 @@ export default {
         }).catch((error) => {
             console.log('Error:', error);
         });
+        
+        this.leaflet.neighborhood_markers.forEach((neighborhood) => {
+            neighborhood.marker = L.marker(neighborhood.location).addTo(this.leaflet.map);
+            neighborhood.marker._icon.classList.add("huechange");
+        })
+
+        $(".leaflet-pane.leaflet-shadow-pane").remove();
+
     }
 }
 </script>
@@ -223,5 +231,8 @@ export default {
     border: solid 1px white;
     text-align: center;
     cursor: pointer;
+}
+img.huechange { 
+    filter: hue-rotate(120deg); 
 }
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -174,16 +174,11 @@ export default {
         }).catch((error) => {
             console.log('Error:', error);
         });
-<<<<<<< HEAD
         
         this.leaflet.neighborhood_markers.forEach((neighborhood) => {
             neighborhood.marker = L.marker(neighborhood.location).addTo(this.leaflet.map);
             neighborhood.marker._icon.classList.add("huechange");
         })
-
-        $(".leaflet-pane.leaflet-shadow-pane").remove();
-
-=======
 
         this.getJSON('http://localhost:8000/incidents').then((results) => {
             // crime data
@@ -197,7 +192,8 @@ export default {
         }).catch((error) => {
             console.log('Error', error);
         });
->>>>>>> origin/chris
+
+        $(".leaflet-pane.leaflet-shadow-pane").remove();
     }
 }
 </script>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -6,7 +6,10 @@ export default {
         return {
             view: 'map',
             codes: [],
-            neighborhoods: [],
+            neighborhoods: {1:'Conway/Battlecreek/Highwood',2:'Greater East Side', 3:'West Side', 4:'Daytons Bluff',
+        5:'Payne/Phalen',6:'North End',7:'Thomas/Dale(Frogtown)', 8:'Summit/University', 9:'West Seventh', 10:'Como', 
+        11:'Hamline/Midway', 12:'St. Anthony', 13:'Union Park', 14:'Macalester-Groveland', 15:'Highland', 
+        16:'Summit Hill', 17:'Capitol River'},
             incidents: [],
             leaflet: {
                 map: null,
@@ -21,28 +24,29 @@ export default {
                     se: {lat: 44.883658, lng: -92.993787}
                 },
                 neighborhood_markers: [
-                    {location: [44.942068, -93.020521], marker: null},
-                    {location: [44.977413, -93.025156], marker: null},
-                    {location: [44.931244, -93.079578], marker: null},
-                    {location: [44.956192, -93.060189], marker: null},
-                    {location: [44.978883, -93.068163], marker: null},
-                    {location: [44.975766, -93.113887], marker: null},
-                    {location: [44.959639, -93.121271], marker: null},
-                    {location: [44.947700, -93.128505], marker: null},
-                    {location: [44.930276, -93.119911], marker: null},
-                    {location: [44.982752, -93.147910], marker: null},
-                    {location: [44.963631, -93.167548], marker: null},
-                    {location: [44.973971, -93.197965], marker: null},
-                    {location: [44.949043, -93.178261], marker: null},
-                    {location: [44.934848, -93.176736], marker: null},
-                    {location: [44.913106, -93.170779], marker: null},
-                    {location: [44.937705, -93.136997], marker: null},
-                    {location: [44.949203, -93.093739], marker: null}
+                    {location: [44.942068, -93.020521], marker: null, neighborhood_name:'Conway/Battlecreek/Highwood'},
+                    {location: [44.977413, -93.025156], marker: null, neighborhood_name:'Greater East Side'},
+                    {location: [44.931244, -93.079578], marker: null, neighborhood_name:'West Side'},
+                    {location: [44.956192, -93.060189], marker: null, neighborhood_name:'Daytons Bluff'},
+                    {location: [44.978883, -93.068163], marker: null, neighborhood_name:'Payne/Phalen'},
+                    {location: [44.975766, -93.113887], marker: null, neighborhood_name:'North End'},
+                    {location: [44.959639, -93.121271], marker: null, neighborhood_name:'Thomas/Dale(Frogtown)'},
+                    {location: [44.947700, -93.128505], marker: null, neighborhood_name:'Summit/University'},
+                    {location: [44.930276, -93.119911], marker: null, neighborhood_name:'West Seventh'},
+                    {location: [44.982752, -93.147910], marker: null, neighborhood_name:'Como'},
+                    {location: [44.963631, -93.167548], marker: null, neighborhood_name:'Hamline/Midway'},
+                    {location: [44.973971, -93.197965], marker: null, neighborhood_name:'St. Anthony'},
+                    {location: [44.949043, -93.178261], marker: null, neighborhood_name:'Union Park'},
+                    {location: [44.934848, -93.176736], marker: null, neighborhood_name:'Macalester-Groveland'},
+                    {location: [44.913106, -93.170779], marker: null, neighborhood_name:'Highland'},
+                    {location: [44.937705, -93.136997], marker: null, neighborhood_name:'Summit Hill'},
+                    {location: [44.949203, -93.093739], marker: null, neighborhood_name:'Capitol River'}
                 ]
             },
             currentAddress: '',
             currentMarker: null,
             inputError: false,
+            currentBoundingBox: {},
         };
     },
     methods: {
@@ -94,8 +98,14 @@ export default {
             $(".leaflet-popup").remove();
             $(".leaflet-pane.leaflet-shadow-pane").remove();
         },
-        isInBoundingBox(lat, lon, x1, x2, y1, y2) {
-            return lat >= x1 && lat <= x2 && lon >= y1 && lon <= y2;
+        isInBoundingBox(lat, lon) {
+            return lat >= this.leaflet.bounds.se.lat && lat <= this.leaflet.bounds.nw.lat && lon >= this.leaflet.bounds.nw.lng && lon <= this.leaflet.bounds.se.lng;
+        },
+        isInBounds(lat, lon, currentBounds) {
+            console.log(currentBounds);
+            let se = currentBounds._southWest
+            let nw = currentBounds._northEast
+            return lat >= se.lat && lat <= nw.lat && lon >= se.lng && lon <= nw.lng;
         },
         onInput(e) {
             this.currentAddress = e.target.value;
@@ -120,9 +130,22 @@ export default {
             const currentCenter = this.leaflet.map.getCenter().lat + ',' + this.leaflet.map.getCenter().lng;
             this.getJSON('https://nominatim.openstreetmap.org/search?q=' + currentCenter + '&format=json').then((result) => {
                 this.currentAddress = result[0].display_name;
+                this.currentBoundingBox = this.leaflet.map.getBounds();
             }).catch((error) => {
                 console.log(error);
             });
+            this.getJSON('http://localhost:8000/incidents').then((results) => {
+            // crime data
+            results.sort((inc1,inc2) => new Date(inc2.date_time) - new Date(inc1.date_time));
+            results.filter((incident) => {
+                return this.isInBounds(this.leaflet.neighborhood_markers[incident.neighborhood_number-1].location[0], this.leaflet.neighborhood_markers[incident.neighborhood_number-1].location[1], this.currentBoundingBox);
+            
+            });
+            this.incidents = results;
+            console.log(results);
+        }).catch((error) => {
+            console.log('Error', error);
+        });
         }
     },
     mounted() {
@@ -150,6 +173,19 @@ export default {
             });
         }).catch((error) => {
             console.log('Error:', error);
+        });
+
+        this.getJSON('http://localhost:8000/incidents').then((results) => {
+            // crime data
+            results.sort((inc1,inc2) => new Date(inc2.date_time) - new Date(inc1.date_time));
+            results.filter((incident) => {
+                return this.isInBoundingBox(this.leaflet.neighborhood_markers[incident.neighborhood_number-1].location[0], this.leaflet.neighborhood_markers[incident.neighborhood_number-1].location[1]);
+            
+            });
+            this.incidents = results;
+            console.log(results);
+        }).catch((error) => {
+            console.log('Error', error);
         });
     }
 }
@@ -187,6 +223,23 @@ export default {
             </div>
         </div>
     </div>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Neighborhood</th>
+                <th>Incident Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            
+            <tr v-for="(item, index) in incidents">
+                <td>{{ index + 1 }}</td>
+                <td>{{ neighborhoods[item.neighborhood_number] }}</td>
+                <td>{{ item.incident}}</td>
+            </tr>
+        </tbody>
+    </table>
     <div v-if="view === 'new_incident'">
         <!-- Replace this with your actual form: can be done here or by making a new component -->
         <div class="grid-container">


### PR DESCRIPTION
Retrieve data from your St. Paul Crime API
By default, include 1,000 most recent crimes in the database
Populate a table with one row per crime (use neighborhood_name rather than neighborhood_number, and incident_type rather than code)
Table should be ordered with most recent on top 
Only show crimes that occurred in neighborhoods visible on the map
HINT: get lat/long coordinates for the NW and SE corners of the map to use as the min/max lat/long coordinates
Draw markers on the map for each neighborhood
Marker should have popup to show the number of crimes committed in that neighborhood